### PR TITLE
olark.com is a legitimate website and should not be blocked

### DIFF
--- a/domains.txt
+++ b/domains.txt
@@ -44287,7 +44287,6 @@ address=/oktits.com/0.0.0.0
 address=/oktube.ru/0.0.0.0
 address=/ok-ua.info/0.0.0.0
 address=/olalalife.com/0.0.0.0
-address=/olark.com/0.0.0.0
 address=/olasco-office.biz/0.0.0.0
 address=/olcmeapp.com/0.0.0.0
 address=/oldensales.com/0.0.0.0

--- a/hostnames.txt
+++ b/hostnames.txt
@@ -17764,6 +17764,7 @@
 0.0.0.0 log.nuomi.com
 0.0.0.0 log.nvwa.baofeng.com
 0.0.0.0 logo.ifarm.science
+0.0.0.0 log.olark.com
 0.0.0.0 log.omiga-plus.com
 0.0.0.0 logo.naulogistics.com
 0.0.0.0 logonext.tv.kuyun.com
@@ -26190,6 +26191,7 @@
 0.0.0.0 stats.nowpublic.com
 0.0.0.0 stats.nutritiondata.com
 0.0.0.0 stats.nymag.com
+0.0.0.0 stats.olark.com
 0.0.0.0 stats.openload.co
 0.0.0.0 stats.orangemail.orange.fr
 0.0.0.0 stats.ourstats.de


### PR DESCRIPTION
Updated to block stats.olark.com and log.olark.com as is seen in other blocklists but still allow access to the olark.com homepage