### PR TITLE
removed redirector.gvt1.com

### DIFF
--- a/hostnames.txt
+++ b/hostnames.txt
@@ -23521,7 +23521,6 @@
 0.0.0.0 redirect.la.idealab.com
 0.0.0.0 redirect.leadstracker.net
 0.0.0.0 redirect.linksummary.com
-0.0.0.0 redirector.gvt1.com
 0.0.0.0 redirector.themobilehub.net
 0.0.0.0 redirects.coldhardcash.com
 0.0.0.0 redirect.searchignite.com


### PR DESCRIPTION
Please remove `gvt1.com` permanently from blocking lists since it's used by **Google Play** for downloading app updates.