### PR TITLE
removed a1.mzstatic.com

### DIFF
--- a/hostnames.txt
+++ b/hostnames.txt
@@ -739,7 +739,6 @@
 0.0.0.0 a1.jandan.net
 0.0.0.0 a1.juzih.com
 0.0.0.0 a1.lmaq.cn
-0.0.0.0 a1.mzstatic.com
 0.0.0.0 a.1nimo.com
 0.0.0.0 a1.peoplecdn.cn
 0.0.0.0 a1.qqjay.com


### PR DESCRIPTION
a1.mzstatic.com is used to verify iTunes purchases, downloading purchased movies will fail when blocked