### PR TITLE
Remove queda212..duckdns.org

### DIFF
--- a/hostnames.txt
+++ b/hostnames.txt
@@ -39396,8 +39396,6 @@
 :: quatest.sixstarsent.com
 0.0.0.0 qubitanalytics.appspot.com
 :: qubitanalytics.appspot.com
-0.0.0.0 queda212..duckdns.org
-:: queda212..duckdns.org
 0.0.0.0 queda212.duckdns.org
 :: queda212.duckdns.org
 0.0.0.0 quedabesouro.ddns.net


### PR DESCRIPTION
Contains '..' which is not a legal domain name