### PR TITLE
Added Little Snitch lsrules urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ All domain and combined lists will block the canary domain `use-application-dns.
 | [adblock/adblock.txt](https://github.com/notracking/hosts-blocklists/raw/master/adblock/adblock.txt)| AdblockPlus | Adguard Home, uBlock Origin |
 | [hostnames.txt](https://github.com/notracking/hosts-blocklists/raw/master/hostnames.txt) | hosts | Dnsmasq (old: pre version 2.80) |
 | [domains.txt](https://github.com/notracking/hosts-blocklists/raw/master/domains.txt) | config | Dnsmasq (old: pre version 2.80) |
-| [domains.lsrules](https://raw.githubusercontent.com/chrispaynter/little-snitch-block-lists/master/dist/notracking-domains.lsrules) | lsrules | Little Snitch |
-| [hostnames.lsrules](https://raw.githubusercontent.com/chrispaynter/little-snitch-block-lists/master/dist/notracking-hostnames.lsrules) | lsrules | Little Snitch |
+| [domains.lsrules](https://raw.githubusercontent.com/chrispaynter/little-snitch-rules/master/dist/notracking-domains.lsrules) | lsrules | Little Snitch |
+| [hostnames.lsrules](https://raw.githubusercontent.com/chrispaynter/little-snitch-rules/master/dist/notracking-hostnames.lsrules) | lsrules | Little Snitch |
 
 ## How to install
  - [Instructions for AdblockPlus](https://github.com/notracking/hosts-blocklists/wiki/Install-AdblockPlus) (eg. [uBlock](https://github.com/gorhill/uBlock), [Adguard Home](https://github.com/AdguardTeam/AdGuardHome/))

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The NoTracking blocklist is a DNS based filter list for blocking ads, malware, p
  - Blocks malware servers
  - Blocks webminers
  - Blocks phishing servers
- 
+
 ## Optimization
 The optimizer makes full use of domainname based wildcard filtering `*.doubleclick.net`, this reduces the chance of missing any new subdomains and significantly reduces the size of the blocklists. Hostnames that cannot be blocked on a domain level will still be listed in a regular hostname based blocklist.
 
@@ -32,6 +32,8 @@ All domain and combined lists will block the canary domain `use-application-dns.
 | [adblock/adblock.txt](https://github.com/notracking/hosts-blocklists/raw/master/adblock/adblock.txt)| AdblockPlus | Adguard Home, uBlock Origin |
 | [hostnames.txt](https://github.com/notracking/hosts-blocklists/raw/master/hostnames.txt) | hosts | Dnsmasq (old: pre version 2.80) |
 | [domains.txt](https://github.com/notracking/hosts-blocklists/raw/master/domains.txt) | config | Dnsmasq (old: pre version 2.80) |
+| [domains.lsrules](https://raw.githubusercontent.com/chrispaynter/little-snitch-block-lists/master/dist/notracking-domains.lsrules) | lsrules | Little Snitch |
+| [hostnames.lsrules](https://raw.githubusercontent.com/chrispaynter/little-snitch-block-lists/master/dist/notracking-hostnames.lsrules) | lsrules | Little Snitch |
 
 ## How to install
  - [Instructions for AdblockPlus](https://github.com/notracking/hosts-blocklists/wiki/Install-AdblockPlus) (eg. [uBlock](https://github.com/gorhill/uBlock), [Adguard Home](https://github.com/AdguardTeam/AdGuardHome/))


### PR DESCRIPTION
I'm creating a [resource](https://github.com/chrispaynter/little-snitch-rules) for [Little Snitch](https://www.obdev.at/products/littlesnitch/index.html) users to subscribe to block lists.

I started with your lists because they are really good.

The `lsrules` files are automatically updated every day, and everything is orchestrated from this repo:
https://github.com/chrispaynter/little-snitch-rules

I thought I'd offer a PR to include the raw lsrules files on your repo, if you are interested. Good subscription lists for Little Snitch are hard to come by.